### PR TITLE
Avoid conflicts with existing Veritrans module on drupal.org when try…

### DIFF
--- a/Web/commerce_veritrans_web.info
+++ b/Web/commerce_veritrans_web.info
@@ -4,17 +4,3 @@ package = Commerce (payment)
 dependencies[] = commerce_veritrans
 
 core = 7.x
-
-; Information added by Drupal.org packaging script on 2015-07-27
-version = "7.x-1.1"
-core = "7.x"
-project = "commerce_veritrans"
-datestamp = "1419854882"
-
-
-; Information added by Drupal.org packaging script on 2015-07-27
-version = "7.x-1.1"
-core = "7.x"
-project = "commerce_veritrans"
-datestamp = "1421390881"
-

--- a/commerce_veritrans.info
+++ b/commerce_veritrans.info
@@ -9,10 +9,3 @@ dependencies[] = commerce_customer
 ; dependencies[] = libraries
 
 core = 7.x
-
-; Information added by Drupal.org packaging script on 2015-07-27
-version = "7.x-1.1"
-core = "7.x"
-project = "commerce_veritrans"
-datestamp = "1421390881"
-


### PR DESCRIPTION
Avoid conflicts with existing Veritrans module on drupal.org when trying to check the module update page.